### PR TITLE
Add missing requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.pkl
 *.pt
 __pycache__
+venv

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,5 +1,6 @@
 arxiv==2.0.0
-python-telegram-bot==20.2
+python-telegram-bot[job-queue]==20.2
 scikit-learn
 pandas
 torch
+telethon


### PR DESCRIPTION
### Description

- `telethon` is shown as required package
- `JobQueue` is an optional feature in python-telegram-bot v20+ and is not included by default

### Test

Initial project and run example command successfully

```
python3.9 -m venv venv  
source venv/bin/activate 
pip install -r requirement.txt 
python arxiv_checker.py --first_backcheck_day 3 --keywords llm,search,reasoning,planning,optimization       
```